### PR TITLE
fix #2: autoFix empty the file when there are syntax errors

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -110,7 +110,7 @@ export async function autoFix(
     output,
     results: [result],
   } = await lint(document.uri, originalText, settings, true)
-  if (result.ignored) {
+  if (result.ignored || result.errored) {
     return []
   }
 


### PR DESCRIPTION
fix #2 