### PR TITLE
workaround when output is empty string

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -110,7 +110,7 @@ export async function autoFix(
     output,
     results: [result],
   } = await lint(document.uri, originalText, settings, true)
-  if (result.ignored) {
+  if (result.ignored || result.errored) {
     return []
   }
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -110,7 +110,7 @@ export async function autoFix(
     output,
     results: [result],
   } = await lint(document.uri, originalText, settings, true)
-  if (result.ignored || result.errored) {
+  if (result.ignored || output === "") {
     return []
   }
 


### PR DESCRIPTION
workaround for #2 