### PR TITLE
Handle stylelint validation errors gracefully

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -188,7 +188,11 @@ export function registerValidateHandlers(
 
       const config = await settings.resolve(document)
       if (config.enable) {
-        await validate(connection, document, config)
+        try {
+          await validate(connection, document, config)
+        } catch (error) {
+          console.error(`Error when trying to validate ${document.uri}`, error)
+        }
       } else {
         connection.sendDiagnostics({
           uri: document.uri,


### PR DESCRIPTION
If the promise returned from the stylelint's validate function rejects, the error is now handled by logging it to stderr.

This means the rejection is no longer unhandled.

`validate` fails for me in projects where I did not have stylelint set up:


> [ ERROR ] 2021-04-29T09:12:24+0200 ] ...nt_nvimCuKCET/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]    "rpc"   "stylelint-lsp" "stderr"        "Error when trying to validate file:///home/grzegorz/projects/cloudify/cloudify-stage/test/cypress/integration/widgets/deployments_view_spec.ts Error: No configuration provided for /home/grzegorz/projects/cloudify/cloudify-stage/test/cypress/integration/widgets/deployments_view_spec.ts\n    at module.exports (/home/grzegorz/projects/open-source/stylelint-lsp/node_modules/stylelint/lib/utils/configurationError.js:10:14)\n    at /home/grzegorz/projects/open-source/stylelint-lsp/node_modules/stylelint/lib/getConfigForFile.js:56:11\n    at async validate (/home/grzegorz/projects/open-source/stylelint-lsp/dist/validate.js:37:36)\n    at async /home/grzegorz/projects/open-source/stylelint-lsp/dist/validate.js:118:17 {\n  code: 78\n}\n"
