### PR TITLE
Fix catching stylelint linting failures

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -138,10 +138,10 @@ export default class Settings {
     uri: string,
     stylelint: typeof globalStylelint
   ): typeof globalStylelint["lint"] {
-    return (...args) => {
+    return async (...args) => {
       if (!this.failedDocuments.has(uri)) {
         try {
-          return stylelint.lint(...args)
+          return await stylelint.lint(...args)
         } catch (error) {
           // log error and disable stylelint for this uri
           console.error(`Error when trying to validate ${uri}`, error)
@@ -150,11 +150,11 @@ export default class Settings {
       }
 
       // empty results will cause validate/autoFix to do nothing
-      return Promise.resolve({
+      return {
         errored: true,
         output: "",
         results: [],
-      })
+      }
     }
   }
 


### PR DESCRIPTION
With v1.2.3, we seem to have regressed with #18 😟 

Stylelint linting failures (e.g. non-existing configuration) result in a rejected promise, not an error being thrown synchronously. Thus,
the failure needs to be caught asynchronously.

Without this fix, there were unhandled promise rejections inside neovim's LSP log:


> [ ERROR ] 2021-05-08T08:54:49+0200 ] ...nt_nvimnOFBMw/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ] "rpc"    "stylelint-lsp" "stderr"        "(node:70348) UnhandledPromiseRejectionWarning: Error: No configuration provided for /home/voreny/projects/personal/supreme-trobot/src/popup.ts\n    at module.exports (/home/voreny/.nvm/versions/node/v14.15.0/lib/node_modules/stylelint-lsp/node_modules/stylelint/lib/utils/configurationError.js:10:14)\n    at /home/voreny/.nvm/versions/node/v14.15.0/lib/node_modules/stylelint-lsp/node_modules/stylelint/lib/getConfigForFile.js:56:11\n    at async validate (/home/voreny/.nvm/versions/node/v14.15.0/lib/node_modules/stylelint-lsp/dist/validate.js:37:36)\n    at async /home/voreny/.nvm/versions/node/v14.15.0/lib/node_modules/stylelint-lsp/dist/validate.js:116:13\n"
> [ ERROR ] 2021-05-08T08:54:49+0200 ] ...nt_nvimnOFBMw/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ] "rpc"    "stylelint-lsp" "stderr"        "(node:70348) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 43)\n"

With this PR, the fix for #19 is working great and the error about the configuration not being provided does not repeat 😄