### PR TITLE
fix(validate): update `STYLELINT_CONFIG_FILES` constant

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -20,11 +20,13 @@ import Settings, { ServerSettings } from "./settings"
 
 const STYLELINT_CONFIG_FILES = [
   ".stylelintignore",
+  "stylelint.config.cjs",
   "stylelint.config.js",
   ".stylelintrc",
   ".stylelintrc.json",
   ".stylelintrc.yaml",
   ".stylelintrc.yml",
+  ".stylelintrc.cjs",
   ".stylelintrc.js",
   "package.json",
 ]


### PR DESCRIPTION
Hi! dear maintainers - this little contribution is to update the `STYLELINT_CONFIG_FILES` to supporting files `.stylelintrc.cjs` and `stylelint.config.cjs` based on [StyleLint config files](https://stylelint.io/user-guide/configure/).

Signed-off-by: Wuelner Martínez <wuelner.martinez@outlook.com>