### PR TITLE
Add IntelliJ support as client with LSP4IJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ save, in response to format requests, or run manually using a command.
 ## Client Implementations
 * [coc-stylelintplus]: a client for [coc.nvim]
 * [nvim-lspconfig]: configs for [neovim]'s built-in lsp support
-
+* [LSP4IJ](https://github.com/redhat-developer/lsp4ij/blob/main/docs/user-defined-ls/stylelint-lsp.md): a free LSP client support for all JetBrains products (IntelliJ, PyCharm, CLion, etc).
+  
 ## Settings
 * **autoFixOnFormat** (default `false`) - automatically apply fixes in response
   to format requests.


### PR DESCRIPTION
Add IntelliJ support as client with LSP4IJ

Please note as stylelint-lsp support in LSP4IJ is new, you will need to install [nighty build](https://github.com/redhat-developer/lsp4ij?tab=readme-ov-file#testing-nightly-builds) by waiting for the release.